### PR TITLE
Feature/#725 modify type adapter factory spec builder

### DIFF
--- a/core/src/main/java/com/infinum/jsonapix/core/adapters/AdapterFactory.kt
+++ b/core/src/main/java/com/infinum/jsonapix/core/adapters/AdapterFactory.kt
@@ -1,5 +1,10 @@
 package com.infinum.jsonapix.core.adapters
 
+import java.lang.reflect.ParameterizedType
+import kotlin.reflect.KClass
+
 interface AdapterFactory {
-    fun getAdapter(type: String): TypeAdapter<*>?
+    fun getAdapter(type: KClass<*>): TypeAdapter<*>?
+
+    fun getAdapter(type: ParameterizedType): TypeAdapter<*>?
 }

--- a/core/src/main/java/com/infinum/jsonapix/core/adapters/AdapterFactory.kt
+++ b/core/src/main/java/com/infinum/jsonapix/core/adapters/AdapterFactory.kt
@@ -1,10 +1,9 @@
 package com.infinum.jsonapix.core.adapters
 
-import java.lang.reflect.ParameterizedType
 import kotlin.reflect.KClass
 
 interface AdapterFactory {
     fun getAdapter(type: KClass<*>): TypeAdapter<*>?
 
-    fun getListAdapter(type: ParameterizedType): TypeAdapter<*>?
+    fun getListAdapter(type: KClass<*>): TypeAdapter<*>?
 }

--- a/core/src/main/java/com/infinum/jsonapix/core/adapters/AdapterFactory.kt
+++ b/core/src/main/java/com/infinum/jsonapix/core/adapters/AdapterFactory.kt
@@ -6,5 +6,5 @@ import kotlin.reflect.KClass
 interface AdapterFactory {
     fun getAdapter(type: KClass<*>): TypeAdapter<*>?
 
-    fun getAdapter(type: ParameterizedType): TypeAdapter<*>?
+    fun getListAdapter(type: ParameterizedType): TypeAdapter<*>?
 }

--- a/core/src/main/java/com/infinum/jsonapix/core/common/JsonApiConstants.kt
+++ b/core/src/main/java/com/infinum/jsonapix/core/common/JsonApiConstants.kt
@@ -63,6 +63,7 @@ object JsonApiConstants {
         const val CONVERT_TO_STRING = "convertToString"
         const val CONVERT_FROM_STRING = "convertFromString"
         const val GET_ADAPTER = "getAdapter"
+        const val GET_LIST_ADAPTER = "getListAdapter"
 
         const val ROOT_LINKS = "rootLinks"
         const val RESOURCE_OBJECT_LINKS = "resourceObjectLinks"

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/TypeAdapterFactorySpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/TypeAdapterFactorySpecBuilder.kt
@@ -11,7 +11,6 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.asClassName
-import java.lang.reflect.ParameterizedType
 import kotlin.reflect.KClass
 
 public class TypeAdapterFactorySpecBuilder {
@@ -64,15 +63,14 @@ public class TypeAdapterFactorySpecBuilder {
     private fun getListAdapterFunSpec(): FunSpec {
         return FunSpec.builder(JsonApiConstants.Members.GET_LIST_ADAPTER)
             .addModifiers(KModifier.OVERRIDE)
-            .addParameter("type", ParameterizedType::class.asClassName())
+            .addParameter("type", KClass::class.asClassName().parameterizedBy(WildcardTypeName.producerOf(Any::class)))
             .returns(
                 TypeAdapter::class
                     .asClassName()
                     .parameterizedBy(WildcardTypeName.producerOf(Any::class))
                     .copy(nullable = true)
             )
-            .addStatement("val qualifiedName = (type.actualTypeArguments.first() as Class<*>).kotlin.qualifiedName")
-            .beginControlFlow("return when(qualifiedName)")
+            .beginControlFlow("return when(type.qualifiedName)")
             .apply {
                 classNames.forEach {
                     addStatement("%S -> TypeAdapterList_${it.simpleName}()", it.canonicalName)

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/TypeAdapterFactorySpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/TypeAdapterFactorySpecBuilder.kt
@@ -43,7 +43,6 @@ public class TypeAdapterFactorySpecBuilder {
     private fun getAdapterFunSpec(): FunSpec {
         return FunSpec.builder(JsonApiConstants.Members.GET_ADAPTER)
             .addModifiers(KModifier.OVERRIDE)
-//            .addParameter("type", String::class.asClassName())
             .addParameter("type", KClass::class.asClassName().parameterizedBy(WildcardTypeName.producerOf(Any::class)))
             .returns(
                 TypeAdapter::class
@@ -63,8 +62,7 @@ public class TypeAdapterFactorySpecBuilder {
     }
 
     private fun getListAdapterFunSpec(): FunSpec {
-        val listQualifiedName = "java.util.List<" + "$" + "{listType.kotlin.qualifiedName}>"
-        return FunSpec.builder(JsonApiConstants.Members.GET_ADAPTER)
+        return FunSpec.builder(JsonApiConstants.Members.GET_LIST_ADAPTER)
             .addModifiers(KModifier.OVERRIDE)
             .addParameter("type", ParameterizedType::class.asClassName())
             .returns(
@@ -73,12 +71,11 @@ public class TypeAdapterFactorySpecBuilder {
                     .parameterizedBy(WildcardTypeName.producerOf(Any::class))
                     .copy(nullable = true)
             )
-            .addStatement("val listType = type.actualTypeArguments.first() as Class<*>")
-            .addStatement("val qualifiedName = %P", listQualifiedName)
+            .addStatement("val qualifiedName = (type.actualTypeArguments.first() as Class<*>).kotlin.qualifiedName")
             .beginControlFlow("return when(qualifiedName)")
             .apply {
                 classNames.forEach {
-                    addStatement("%S -> TypeAdapterList_${it.simpleName}()", "java.util.List<${it.canonicalName}>")
+                    addStatement("%S -> TypeAdapterList_${it.simpleName}()", it.canonicalName)
                 }
             }
             .addStatement("else -> null")

--- a/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXConverterFactory.kt
+++ b/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXConverterFactory.kt
@@ -20,7 +20,7 @@ class JsonXConverterFactory(private val adapterFactory: AdapterFactory) : Conver
                 JsonXResponseBodyConverter(it)
             }
             is ParameterizedType -> {
-                adapterFactory.getListAdapter(type)?.let {
+                adapterFactory.getListAdapter((type.actualTypeArguments.first() as Class<*>).kotlin)?.let {
                     JsonXResponseBodyConverter(it)
                 }
             }
@@ -38,7 +38,7 @@ class JsonXConverterFactory(private val adapterFactory: AdapterFactory) : Conver
                 JsonXRequestBodyConverter(it)
             }
             is ParameterizedType -> {
-                adapterFactory.getListAdapter(type)?.let {
+                adapterFactory.getListAdapter((type.actualTypeArguments.first() as Class<*>).kotlin)?.let {
                     JsonXRequestBodyConverter(it)
                 }
             }

--- a/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXConverterFactory.kt
+++ b/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXConverterFactory.kt
@@ -7,8 +7,6 @@ import okhttp3.ResponseBody
 import retrofit2.Converter
 import retrofit2.Retrofit
 import java.lang.reflect.ParameterizedType
-import kotlin.reflect.KClass
-import kotlin.reflect.typeOf
 
 class JsonXConverterFactory(private val adapterFactory: AdapterFactory) : Converter.Factory() {
 
@@ -22,7 +20,7 @@ class JsonXConverterFactory(private val adapterFactory: AdapterFactory) : Conver
                 JsonXResponseBodyConverter(it)
             }
             is ParameterizedType -> {
-                adapterFactory.getAdapter(type)?.let {
+                adapterFactory.getListAdapter(type)?.let {
                     JsonXResponseBodyConverter(it)
                 }
             }
@@ -40,7 +38,7 @@ class JsonXConverterFactory(private val adapterFactory: AdapterFactory) : Conver
                 JsonXRequestBodyConverter(it)
             }
             is ParameterizedType -> {
-                adapterFactory.getAdapter(type)?.let {
+                adapterFactory.getListAdapter(type)?.let {
                     JsonXRequestBodyConverter(it)
                 }
             }

--- a/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXConverterFactory.kt
+++ b/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXConverterFactory.kt
@@ -7,6 +7,8 @@ import okhttp3.ResponseBody
 import retrofit2.Converter
 import retrofit2.Retrofit
 import java.lang.reflect.ParameterizedType
+import kotlin.reflect.KClass
+import kotlin.reflect.typeOf
 
 class JsonXConverterFactory(private val adapterFactory: AdapterFactory) : Converter.Factory() {
 
@@ -16,12 +18,11 @@ class JsonXConverterFactory(private val adapterFactory: AdapterFactory) : Conver
         retrofit: Retrofit
     ): Converter<ResponseBody, *>? =
         when (type) {
-            is Class<*> -> adapterFactory.getAdapter(type.kotlin.qualifiedName.orEmpty())?.let {
+            is Class<*> -> adapterFactory.getAdapter(type.kotlin)?.let {
                 JsonXResponseBodyConverter(it)
             }
             is ParameterizedType -> {
-                val listType = type.actualTypeArguments.first() as Class<*>
-                adapterFactory.getAdapter("java.util.List<${listType.kotlin.qualifiedName}>")?.let {
+                adapterFactory.getAdapter(type)?.let {
                     JsonXResponseBodyConverter(it)
                 }
             }
@@ -35,12 +36,11 @@ class JsonXConverterFactory(private val adapterFactory: AdapterFactory) : Conver
         retrofit: Retrofit
     ): Converter<*, RequestBody>? =
         when (type) {
-            is Class<*> -> adapterFactory.getAdapter(type.kotlin.qualifiedName.orEmpty())?.let {
+            is Class<*> -> adapterFactory.getAdapter(type.kotlin)?.let {
                 JsonXRequestBodyConverter(it)
             }
             is ParameterizedType -> {
-                val listType = type.actualTypeArguments.first() as Class<*>
-                adapterFactory.getAdapter("java.util.List<${listType.kotlin.qualifiedName}>")?.let {
+                adapterFactory.getAdapter(type)?.let {
                     JsonXRequestBodyConverter(it)
                 }
             }


### PR DESCRIPTION
https://app.productive.io/1-infinum/tasks/2547892

This PR contains changes made to simplify getTypeAdapter() usage for non retrofit users with passing either `Class<*>` or full `ParameterizedType` in case of lists.